### PR TITLE
fix: use Cargo.toml version for --version flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ impl EventReader for CrosstermEventReader {
 #[derive(Parser, Debug)]
 #[command(name = "jarvis")]
 #[command(author = "Luckystrike561")]
-#[command(version = "0.1.0")]
+#[command(version = env!("CARGO_PKG_VERSION"))]
 #[command(about = "Your trusted AI assistant for automating scripts", long_about = None)]
 struct Args {
     /// Path to the base directory to search for bash scripts


### PR DESCRIPTION
## Summary
- Fixes hardcoded version string in CLI argument parser to automatically use the version from Cargo.toml
- Previously `jarvis --version` showed "0.1.0" while the actual version in Cargo.toml is "0.1.3"
- Now uses `env!("CARGO_PKG_VERSION")` macro which reads the version at compile time from Cargo.toml
- Ensures version displayed by `--version` flag always matches the package version without manual updates

## Changes
- Updated `src/main.rs` line 36 to use `env!("CARGO_PKG_VERSION")` instead of hardcoded "0.1.0"

## Testing
- All 90 tests pass
- Manually verified `jarvis --version` now correctly shows "jarvis 0.1.3"