### PR TITLE
fix: ensure binaries are built with correct version from Cargo.toml

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -18,9 +18,40 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  wait-for-version-sync:
+    name: Wait for Version Sync
+    runs-on: ubuntu-latest
+    # Only run this job when triggered by release event (not manual)
+    if: github.event_name == 'release'
+    steps:
+      - name: Wait for version sync workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Waiting for version sync workflow to complete..."
+          # Wait up to 2 minutes for the version sync workflow
+          for i in {1..24}; do
+            # Check if version sync workflow has completed
+            STATUS=$(gh run list --workflow=release-version-sync.yml --limit 1 --json status --jq '.[0].status')
+            echo "Attempt $i/24: Version sync status: $STATUS"
+            
+            if [ "$STATUS" = "completed" ]; then
+              echo "Version sync completed!"
+              exit 0
+            fi
+            
+            sleep 5
+          done
+          
+          echo "Warning: Version sync workflow did not complete in time"
+          exit 1
+
   build-release:
     name: Build Release Binaries
     runs-on: ${{ matrix.os }}
+    # Wait for version sync when triggered by release, skip for manual
+    needs: [wait-for-version-sync]
+    if: always() && (needs.wait-for-version-sync.result == 'success' || github.event_name == 'workflow_dispatch')
     strategy:
       matrix:
         include:
@@ -37,7 +68,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
+          # For release events, checkout main (which has updated version)
+          # For manual dispatch, checkout the specified tag
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || 'main' }}
 
       - name: Install Devbox
         uses: jetify-com/devbox-install-action@v0.14.0


### PR DESCRIPTION
## Summary

- Fixes release binaries showing incorrect version (0.1.3) when release tag is v0.1.4
- Adds workflow synchronization to ensure version-sync completes before building binaries
- Changes checkout strategy to use main branch (with updated version) instead of release tag

## Problem

The `--version` flag in v0.1.4 release binaries showed `jarvis 0.1.3` instead of `jarvis 0.1.4`. This happened because:

1. Release v0.1.4 is published (tag points to commit with version 0.1.3 in Cargo.toml)
2. Both `release-version-sync` and `release-build` workflows trigger simultaneously
3. `release-build` checks out the release tag (old commit with 0.1.3)
4. Rust compiles binaries with `CARGO_PKG_VERSION` from Cargo.toml (0.1.3)
5. Meanwhile, `release-version-sync` updates main branch with 0.1.4

## Solution

1. Added `wait-for-version-sync` job that polls for version-sync workflow completion (up to 2 minutes)
2. Made `build-release` depend on successful version sync
3. Changed checkout from release tag to `main` branch for release events
4. Manual workflow dispatches still support checking out specific tags

## Testing

- ✅ Local build verified: `cargo build --release && ./target/release/jarvis --version` shows `0.1.4`
- ✅ Workflow syntax validated
- Ready for testing on next release