### PR TITLE
fix: add checkout step before gh CLI in release build workflow

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -24,6 +24,9 @@ jobs:
     # Only run this job when triggered by release event (not manual)
     if: github.event_name == 'release'
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
       - name: Wait for version sync workflow
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Fixes the failing release build workflow ([run #21725191120](https://github.com/Luckystrike561/jarvis/actions/runs/21725191120))
- The `wait-for-version-sync` job was failing with `fatal: not a git repository` because the `gh run list` command requires a git repository context
- Added `actions/checkout@v6` step before using the `gh` CLI

## Root Cause

The `gh` CLI with `--workflow` flag needs to be run from within a git repository to determine the repository context. The job was attempting to run `gh run list --workflow=release-version-sync.yml` without first checking out the repository.