### PR TITLE
docs: add module-level documentation to all source files

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,45 @@
+//! # Jarvis CLI Entry Point
+//!
+//! This is the main entry point for the Jarvis TUI application.
+//!
+//! ## Overview
+//!
+//! Jarvis is a beautiful terminal user interface for discovering and executing
+//! scripts with zero configuration. It automatically finds scripts in your project
+//! and presents them in an organized, searchable interface.
+//!
+//! ## Usage
+//!
+//! ```bash
+//! # Use current directory
+//! jarvis
+//!
+//! # Use a specific directory
+//! jarvis --path /path/to/project
+//!
+//! # Debug mode - print discovered scripts and exit
+//! jarvis --debug
+//! ```
+//!
+//! ## Architecture
+//!
+//! The application follows a simple architecture:
+//!
+//! 1. **Discovery**: Scans for script files in the project directory
+//! 2. **Parsing**: Extracts functions/scripts from discovered files
+//! 3. **UI**: Presents scripts in an interactive TUI with search and categories
+//! 4. **Execution**: Runs selected scripts with full terminal access
+//!
+//! ## Key Bindings
+//!
+//! - `q` / `Q` - Quit the application
+//! - `j` / `Down` - Move selection down
+//! - `k` / `Up` - Move selection up
+//! - `Enter` - Execute selected script or expand/collapse category
+//! - `/` - Enter search mode
+//! - `Tab` - Toggle focus between panes
+//! - `i` - Show/hide info modal
+
 use jarvis::script;
 use jarvis::ui;
 use jarvis::ui::App;

--- a/src/script/devbox_parser.rs
+++ b/src/script/devbox_parser.rs
@@ -1,3 +1,43 @@
+//! # Devbox Configuration Parser
+//!
+//! This module parses `devbox.json` files to extract Devbox scripts for display
+//! in the Jarvis TUI.
+//!
+//! ## Overview
+//!
+//! Devbox scripts are defined in the `shell.scripts` section of `devbox.json`.
+//! Scripts can be either strings or arrays of commands:
+//!
+//! ```json
+//! {
+//!   "shell": {
+//!     "scripts": {
+//!       "build": "cargo build --release",
+//!       "check": ["cargo clippy", "cargo fmt --check"]
+//!     }
+//!   }
+//! }
+//! ```
+//!
+//! ## Key Types
+//!
+//! - [`ScriptValue`] - Handles both string and array script formats
+//! - [`DevboxJson`] - Top-level devbox.json structure
+//! - [`DevboxShell`] - The shell configuration containing scripts
+//! - [`DevboxScript`] - Represents a single script with display metadata
+//! - [`parse_devbox_json`] - Main parsing function
+//!
+//! ## Script Value Formats
+//!
+//! The parser handles two common formats:
+//!
+//! | Format | Example | Stored As |
+//! |--------|---------|-----------|
+//! | String | `"cargo build"` | `ScriptValue::Single` |
+//! | Array | `["cargo clippy", "cargo fmt"]` | `ScriptValue::Multiple` |
+//!
+//! Array commands are joined with `&&` for description display.
+
 use anyhow::{Context, Result};
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;

--- a/src/script/discovery.rs
+++ b/src/script/discovery.rs
@@ -1,3 +1,37 @@
+//! # Script Discovery
+//!
+//! This module handles automatic discovery of script files in the project directory.
+//!
+//! ## Supported Script Types
+//!
+//! - **Bash scripts** (`.sh` files) - Functions are extracted by the parser
+//! - **npm scripts** (`package.json`) - Scripts from the "scripts" section
+//! - **Devbox scripts** (`devbox.json`) - Scripts from the "shell.scripts" section
+//! - **Taskfiles** (`Taskfile.yml`, etc.) - Tasks defined in go-task format
+//!
+//! ## Discovery Locations
+//!
+//! Scripts are discovered from multiple locations:
+//!
+//! | Location | Depth | Description |
+//! |----------|-------|-------------|
+//! | `./` | 1 | Root directory (shallow scan) |
+//! | `./script/` | 2 | Script subdirectory |
+//! | `./scripts/` | 2 | Scripts subdirectory |
+//! | `./jarvis/` | 2 | Jarvis-specific directory |
+//!
+//! ## Category Assignment
+//!
+//! Each discovered script is assigned a category based on its source:
+//! - Root scripts use the filename (without extension) as category
+//! - Subdirectory scripts use the subdirectory name as category
+//!
+//! ## Key Functions
+//!
+//! - [`discover_scripts`] - Full recursive discovery with depth 2
+//! - [`discover_scripts_shallow`] - Shallow discovery with depth 1
+//! - [`format_display_name`] - Converts snake_case to Title Case
+
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};

--- a/src/script/executor.rs
+++ b/src/script/executor.rs
@@ -1,3 +1,48 @@
+//! # Script Executor
+//!
+//! This module provides interactive execution of scripts and functions with full
+//! terminal access. It handles the actual running of discovered scripts, ensuring
+//! that interactive tools (like `gum`, `fzf`, etc.) work correctly.
+//!
+//! ## Supported Script Types
+//!
+//! | Type | Function | Command Pattern |
+//! |------|----------|-----------------|
+//! | Bash | `execute_function_interactive` | `source script.sh && function_name` |
+//! | npm | `execute_npm_script_interactive` | `npm run script_name` |
+//! | Devbox | `execute_devbox_script_interactive` | `devbox run script_name` |
+//! | Task | `execute_task_interactive` | `task --taskfile path task_name` |
+//!
+//! ## Key Design Decisions
+//!
+//! ### Full Terminal Access
+//!
+//! All execution functions inherit stdin, stdout, and stderr from the parent process:
+//!
+//! ```ignore
+//! Command::new("bash")
+//!     .stdin(Stdio::inherit())
+//!     .stdout(Stdio::inherit())
+//!     .stderr(Stdio::inherit())
+//! ```
+//!
+//! This allows scripts to:
+//! - Read user input interactively
+//! - Display colored output
+//! - Use TUI tools like `gum`, `fzf`, `dialog`
+//!
+//! ### Working Directory
+//!
+//! Each executor changes to the script's directory before execution, ensuring
+//! relative paths in scripts work correctly.
+//!
+//! ### Input Validation
+//!
+//! All executors validate:
+//! - Path existence and type (file vs directory)
+//! - Required config files (package.json, devbox.json, Taskfile)
+//! - Valid identifiers (for bash function names)
+
 use anyhow::{Context, Result};
 use std::path::Path;
 use std::process::{Command, Stdio};

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -1,3 +1,34 @@
+//! # Script Module
+//!
+//! This module provides functionality for discovering, parsing, and executing
+//! scripts from various sources.
+//!
+//! ## Supported Script Types
+//!
+//! | Type | File | Parser |
+//! |------|------|--------|
+//! | Bash | `*.sh` | [`parser::parse_script`] |
+//! | npm | `package.json` | [`npm_parser::parse_package_json`] |
+//! | Devbox | `devbox.json` | [`devbox_parser::parse_devbox_json`] |
+//! | Task | `Taskfile.yml` | [`task_parser::list_tasks`] |
+//!
+//! ## Discovery
+//!
+//! Scripts are automatically discovered from:
+//! - Root directory (`./`) - shallow scan
+//! - `./script/` subdirectory
+//! - `./scripts/` subdirectory
+//! - `./jarvis/` subdirectory
+//!
+//! See [`discovery`] module for details.
+//!
+//! ## Execution
+//!
+//! All script types support interactive execution with full terminal access,
+//! allowing scripts to use stdin/stdout/stderr directly.
+//!
+//! See [`executor`] module for details.
+
 pub mod devbox_parser;
 pub mod discovery;
 pub mod executor;

--- a/src/script/npm_parser.rs
+++ b/src/script/npm_parser.rs
@@ -1,3 +1,38 @@
+//! # npm Package Parser
+//!
+//! This module parses `package.json` files to extract npm scripts for display
+//! in the Jarvis TUI.
+//!
+//! ## Overview
+//!
+//! npm scripts are defined in the `scripts` section of `package.json`:
+//!
+//! ```json
+//! {
+//!   "scripts": {
+//!     "build": "webpack --mode production",
+//!     "test": "jest",
+//!     "lint": "eslint src/"
+//!   }
+//! }
+//! ```
+//!
+//! The parser extracts these scripts and converts them to [`NpmScript`] structs
+//! for display in the TUI.
+//!
+//! ## Key Types
+//!
+//! - [`PackageJson`] - Deserializes the package.json structure
+//! - [`NpmScript`] - Represents a single npm script with display metadata
+//! - [`parse_package_json`] - Main parsing function
+//!
+//! ## Display Name Generation
+//!
+//! Script names are converted to human-readable display names:
+//! - `build` -> "Build"
+//! - `test:unit` -> "Test:unit"
+//! - `pre-commit` -> "Pre Commit"
+
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/src/script/parser.rs
+++ b/src/script/parser.rs
@@ -1,3 +1,53 @@
+//! # Bash Script Parser
+//!
+//! This module parses bash script files to extract function definitions
+//! and their metadata annotations.
+//!
+//! ## Supported Function Formats
+//!
+//! Both standard bash function syntaxes are supported:
+//!
+//! ```bash
+//! # Style 1: name() { }
+//! my_function() {
+//!     echo "Hello"
+//! }
+//!
+//! # Style 2: function name() { }
+//! function my_function() {
+//!     echo "Hello"
+//! }
+//! ```
+//!
+//! ## Metadata Annotations
+//!
+//! Functions can be annotated with special comments:
+//!
+//! ```bash
+//! # @emoji 🚀
+//! # @description Deploy the application to production
+//! deploy_app() {
+//!     ./deploy.sh
+//! }
+//!
+//! # @ignore
+//! _internal_helper() {
+//!     # This function won't appear in the TUI
+//! }
+//! ```
+//!
+//! ### Available Annotations
+//!
+//! | Annotation | Description |
+//! |------------|-------------|
+//! | `@emoji <emoji>` | Display emoji prefix in the TUI |
+//! | `@description <text>` | Custom description for the details panel |
+//! | `@ignore` | Hide the function from the TUI |
+//!
+//! ## Key Types
+//!
+//! - [`ScriptFunction`] - Represents a parsed function with its metadata
+
 use anyhow::{Context, Result};
 use regex::Regex;
 use std::fs;

--- a/src/script/task_parser.rs
+++ b/src/script/task_parser.rs
@@ -1,4 +1,41 @@
-//! Parser for Task (go-task/Taskfile) - uses `task --list-all --json` output.
+//! # Task (go-task) Parser
+//!
+//! This module parses Taskfile configurations using the `task` CLI's JSON output
+//! for display in the Jarvis TUI.
+//!
+//! ## Overview
+//!
+//! Unlike other parsers that read configuration files directly, this parser
+//! invokes `task --list-all --json` to get task information. This approach:
+//!
+//! - Handles complex Taskfile includes and imports
+//! - Respects task visibility and internal tasks
+//! - Gets accurate task descriptions from the CLI
+//!
+//! ## Key Types
+//!
+//! - [`TaskListOutput`] - JSON output from `task --list-all --json`
+//! - [`TaskInfo`] - Single task metadata from the CLI
+//! - [`TaskTask`] - Represents a task with display metadata for the TUI
+//! - [`is_task_available`] - Checks if `task` CLI is installed
+//! - [`list_tasks`] - Main function to list tasks from a Taskfile
+//!
+//! ## CLI Integration
+//!
+//! The parser runs:
+//! ```bash
+//! task --list-all --json --taskfile <path>
+//! ```
+//!
+//! And parses the JSON output which includes:
+//! - Task name and description
+//! - Task summary (fallback for description)
+//! - Location information (file, line, column)
+//!
+//! ## Availability Caching
+//!
+//! The `task` binary availability is cached using [`OnceLock`] to avoid
+//! repeated process spawning during discovery.
 
 use anyhow::{Context, Result};
 use serde::Deserialize;

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -1,3 +1,37 @@
+//! # Application State Management
+//!
+//! This module contains the core application state and logic for the Jarvis TUI.
+//!
+//! ## Overview
+//!
+//! The [`App`] struct holds all application state including:
+//! - List of discovered script functions
+//! - Current selection and scroll positions
+//! - Search mode and query state
+//! - UI focus (which pane is active)
+//! - Expanded/collapsed category state
+//!
+//! ## Navigation Model
+//!
+//! Scripts are displayed in a tree structure with categories:
+//!
+//! ```text
+//! ▶ Category A          (collapsed)
+//! ▼ Category B          (expanded)
+//!   ├─ function_one
+//!   └─ function_two
+//! ▶ Category C          (collapsed)
+//! ```
+//!
+//! The [`TreeItem`] enum represents items in this tree view.
+//!
+//! ## Focus Panes
+//!
+//! The UI has multiple focusable panes managed by [`FocusPane`]:
+//! - `ScriptList` - The main script/category tree
+//! - `Details` - The details panel showing script info
+//! - `Output` - The output panel showing execution results
+
 use crate::script::ScriptFunction;
 use std::collections::HashMap;
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,3 +1,40 @@
+//! # UI Module
+//!
+//! This module provides the terminal user interface components for Jarvis.
+//!
+//! ## Components
+//!
+//! - [`App`] - Application state management (selection, focus, search, etc.)
+//! - [`mod@render`] - Rendering functions for drawing the TUI
+//!
+//! ## Layout
+//!
+//! The UI is organized into several panes:
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────┐
+//! │                    Header                        │
+//! ├─────────────────────┬───────────────────────────┤
+//! │                     │                           │
+//! │   Script List       │      Details Panel        │
+//! │   (categories &     │   (description, emoji)    │
+//! │    functions)       │                           │
+//! │                     ├───────────────────────────┤
+//! │                     │      Output Panel         │
+//! │                     │   (execution results)     │
+//! │                     │                           │
+//! ├─────────────────────┴───────────────────────────┤
+//! │                    Footer                        │
+//! └─────────────────────────────────────────────────┘
+//! ```
+//!
+//! ## Features
+//!
+//! - Tree-based navigation with collapsible categories
+//! - Fuzzy search across all scripts
+//! - Focus switching between panes with Tab
+//! - Scrollable output panel for execution results
+
 pub mod app;
 pub mod render;
 

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -1,3 +1,40 @@
+//! # UI Rendering
+//!
+//! This module handles all rendering logic for the Jarvis TUI.
+//!
+//! ## Overview
+//!
+//! The [`render`] function is the main entry point that draws the entire UI
+//! using the [ratatui] library. It composes multiple rendering helpers to
+//! build the complete interface.
+//!
+//! ## Layout Structure
+//!
+//! The UI is rendered in layers:
+//!
+//! 1. **Header** - Project title and branding
+//! 2. **Search Bar** - Visible when search mode is active
+//! 3. **Body** - Split into left (script list) and right (details/output) panes
+//! 4. **Footer** - Keyboard shortcuts help
+//!
+//! ## Rendering Helpers
+//!
+//! - `render_header` - Draws the top header bar
+//! - `render_search_bar` - Draws the search input when active
+//! - `render_script_tree` - Draws the categorized script list
+//! - `render_details` - Draws the selected script details
+//! - `render_output` - Draws execution output
+//! - `render_footer` - Draws the keyboard shortcuts
+//! - `render_info_modal` - Draws the info popup overlay
+//!
+//! ## Styling
+//!
+//! The UI uses a consistent color scheme:
+//! - Cyan for headers and active elements
+//! - Yellow for categories and highlights
+//! - Green for success indicators
+//! - White/Gray for regular text
+
 use crate::ui::app::{App, FocusPane, TreeItem};
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},


### PR DESCRIPTION
## Summary

- Add `//!` module-level doc comments to all 11 Rust source files
- Document module purpose, key types, and usage patterns for each file
- Fix ambiguous intra-doc link warning in `src/ui/mod.rs`

## Files Updated

| File | Description |
|------|-------------|
| `src/main.rs` | Entry point overview with architecture and key bindings |
| `src/ui/mod.rs` | UI module overview with layout diagram |
| `src/ui/app.rs` | Application state management with tree navigation model |
| `src/ui/render.rs` | Rendering system with layout structure |
| `src/script/mod.rs` | Script module overview with supported types table |
| `src/script/discovery.rs` | Discovery system with search locations table |
| `src/script/parser.rs` | Bash parser with annotation documentation |
| `src/script/executor.rs` | Execution system with supported script types |
| `src/script/npm_parser.rs` | npm package.json parsing overview |
| `src/script/devbox_parser.rs` | Devbox JSON parsing with format examples |
| `src/script/task_parser.rs` | Task (go-task) parser with CLI integration details |

## Verification

- `cargo doc --no-deps` builds with no warnings
- `devbox run check` passes (clippy + format)
- All 122 tests pass

Closes #29