### PR TITLE
fix: update time crate to 0.3.47 (RUSTSEC-2026-0009)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,9 +850,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-derive"
@@ -1534,24 +1534,24 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "libc",
  "num-conv",
  "num_threads",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tokio"


### PR DESCRIPTION
## Summary

- Updates transitive dependency `time` from 0.3.44 to 0.3.47 to resolve [RUSTSEC-2026-0009](https://rustsec.org/advisories/RUSTSEC-2026-0009) (Denial of Service via Stack Exhaustion, severity 6.8)
- Only `Cargo.lock` is changed — no code or `Cargo.toml` changes needed since `ratatui-widgets` already allows `time >= 0.3.47`

## Context

The Security Audit CI check is failing on all open PRs (e.g. #87) because `cargo audit` detects this vulnerability. This fix unblocks those PRs.

## Dependency chain

```
time 0.3.44 → 0.3.47
└── ratatui-widgets 0.3.0
    └── ratatui 0.30.0
        └── jarvis-tui 0.1.11
```