### PR TITLE
fix: improve Makefile parser robustness and filtering

### DIFF
--- a/src/script/executor.rs
+++ b/src/script/executor.rs
@@ -665,6 +665,32 @@ custom_exit() {
     }
 
     #[test]
+    fn test_execute_make_target_interactive_success() {
+        // Only run this test if make is available
+        let make_available = Command::new("make")
+            .arg("--version")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+
+        if !make_available {
+            return;
+        }
+
+        let temp_dir = TempDir::new().unwrap();
+        let makefile = temp_dir.path().join("Makefile");
+
+        let content = ".PHONY: test-echo\ntest-echo:\n\t@echo 'make test success'\n";
+        fs::write(&makefile, content).unwrap();
+
+        let result = execute_make_target_interactive(&makefile, "test-echo");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 0);
+    }
+
+    #[test]
     fn test_execute_just_recipe_interactive_nonexistent_path() {
         let temp_dir = TempDir::new().unwrap();
         let justfile = temp_dir.path().join("justfile");


### PR DESCRIPTION
## Summary

Addresses code review findings from the Makefile parser implementation (issue #32). Improves robustness, code quality, and target filtering accuracy.

## Changes

### High Priority — Safety
- **Remove `.unwrap()` in production code**: Replaced `Regex::new(...).unwrap()` in `parse_make_database()` with `?` + `.context()`. Replaced `line.find('=').unwrap()` / `line.find(':').unwrap()` in `list_targets_from_parsing()` with safe `if let` pattern matching.

### Medium Priority — Features & DRY
- **Extract `SKIP_PATTERNS` constant**: Deduplicated identical 14-element skip patterns array from `parse_make_database()` and `list_targets_from_parsing()` into a module-level `SKIP_PATTERNS` constant using `SCREAMING_SNAKE_CASE`.
- **Plain comment descriptions**: Added fallback so `# Build the project` above a target becomes its description when no `@description` annotation is present. `@description` still takes precedence.
- **Built-in target filtering**: Parse `# Not a target:` markers from `make --print-data-base` output to filter out built-in implicit rules (e.g., `ar`, `lex`, `yacc`).

### Low Priority — Code Quality
- **Artifact target filtering**: Filter targets ending in `.o`, `.a`, `.so`, `.out`, `.obj`, `.lib`, `.dll`, `.dylib`, `.exe` via `ARTIFACT_EXTENSIONS` constant and `is_artifact_target()` helper.
- **Import ordering**: Reordered to follow AGENTS.md convention: `std` > external crates (`anyhow`, `regex`) > internal modules.
- **`HashSet` import**: Moved from inline `std::collections::HashSet` to module-level import.
- **Executor test**: Added `test_execute_make_target_interactive_success` (conditionally runs if `make` is available).

## Tests

Added 7 new tests:
- `test_parse_makefile_annotations_plain_comment_description`
- `test_parse_makefile_annotations_description_overrides_plain_comment`
- `test_parse_make_database_filters_not_a_target`
- `test_parse_make_database_filters_artifact_targets`
- `test_is_artifact_target`
- `test_list_targets_from_parsing_skips_artifact_targets`
- `test_execute_make_target_interactive_success`

All 170 tests pass. `devbox run check` (clippy + fmt) passes with no warnings.

Closes #32